### PR TITLE
Added new Hot Key 'd' to not interfere with default YT caption Hot Keys

### DIFF
--- a/app/ytif_content_script.js
+++ b/app/ytif_content_script.js
@@ -234,6 +234,10 @@
                 case 'w':
                     toggleFullScreen();
                     break;
+                case 'g':
+                    // so that using 'w' doesn't toggle YT deafult caption settings
+                    toggleFullScreen();
+                    break;
                 case 't':
                     // disable theater mode shortcut when fullscreen is active
                     if (isFullscreen()) {


### PR DESCRIPTION
The 'w' hotkey interferes with YouTube captions hotkeys, which use {q,w,o,p}. Every time we toggle the extension, the caption's background keeps toggling. 
So I've added a new hotkey 'd' 